### PR TITLE
Added perTestResources target

### DIFF
--- a/itest/src/01-simple/itest2/src-shared/shared.sc
+++ b/itest/src/01-simple/itest2/src-shared/shared.sc
@@ -1,0 +1,1 @@
+// shared resource file

--- a/itest/src/01-simple/itest2/src/demo2/build.sc
+++ b/itest/src/01-simple/itest2/src/demo2/build.sc
@@ -11,6 +11,9 @@ object Demo extends DemoPluginModule {
 }
 
 def verify(): Command[Unit] = T.command {
+  if(!os.exists(build.millSourcePath / "shared.sc")) {
+    sys.error("No shared source file `shared.sc` found")
+  }
   if(Demo.demo() != "DemoPlugin") sys.error(s"Expected 'DemoPlugin' but was '${Demo.demo()}'")
   ()
 }


### PR DESCRIPTION
This allows providing same sources/resources to each test case.
Those can also be generated, if needed.

Fixes https://github.com/lefou/mill-integrationtest/issues/42
