### PR TITLE
Use a ".bat" suffix for the downloaded mill executable

### DIFF
--- a/integrationtest/src/de/tobiasroeser/mill/integrationtest/MillIntegrationTestModule.scala
+++ b/integrationtest/src/de/tobiasroeser/mill/integrationtest/MillIntegrationTestModule.scala
@@ -298,12 +298,13 @@ trait MillIntegrationTestModule extends TaskModule with ExtraCoursierSupport wit
       case MillVersion(0, 0 | 1 | 2 | 3 | 4, _, _, _) => ""
       case _ => "-assembly"
     }
+    val exeSuffix = if (scala.util.Properties.isWin) ".bat" else ""
     val url = s"https://github.com/lihaoyi/mill/releases/download/${mainVersion.versionTag}/${fullVersion}${suffix}"
 
     val cacheTarget = T.env
       .get("XDG_CACHE_HOME")
       .map(os.Path(_))
-      .getOrElse(os.home / ".cache") / "mill" / "download" / fullVersion
+      .getOrElse(os.home / ".cache") / "mill" / "download" / s"${fullVersion}${exeSuffix}"
 
     if (useCachedMillDownload() && os.exists(cacheTarget)) {
       PathRef(cacheTarget)


### PR DESCRIPTION
This one probably fixes #56, but I can't test it right now and need to publish it, to consume it in our own test suite to actually test it on Windows. Classic bootstrap issue. ;-)