### PR TITLE
Fixed default value for TestInvocation.Targets.noServer

### DIFF
--- a/integrationtest/src/de/tobiasroeser/mill/integrationtest/TestInvocation.scala
+++ b/integrationtest/src/de/tobiasroeser/mill/integrationtest/TestInvocation.scala
@@ -7,7 +7,7 @@ object TestInvocation {
       targets: Seq[String],
       expectedExitCode: Int = 0,
       env: Map[String, String] = Map(),
-      noServer: Boolean = false
+      noServer: Boolean = true
   ) extends TestInvocation {
     override def toString: String =
       getClass().getSimpleName() +


### PR DESCRIPTION
To ensure a sensible default which is also behavioral backward compatible, the correct default is `true`.