### PR TITLE
Readme: Suggest to use `import $file` instead of `import $exec`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,7 +84,7 @@ you should use the following line, which ensures that you use the correct locall
 [source,scala]
 ----
 // build.sc
-import $exec.plugins
+import $file.plugins
 ----
 
 Effectively, at execution time, this line gets replaced by the content of `plugins.sc`,


### PR DESCRIPTION
This is in preparation to $exec becoming unsupported since Mill 0.11.0-M8.