### PR TITLE
Use Mill 0.12.14 with mill-contrib-sonatypecentral plugin for publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 8
+          java-version: 11
           distribution: temurin
 
       - name: Setup GPG secrets for publish
@@ -66,4 +66,9 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: Publish to Maven Central
-        run: ./millw -i mill.scalalib.PublishModule/publishAll --sonatypeCreds "${{ secrets.SONATYPE_CREDS }}" --gpgArgs "--passphrase=${{ secrets.GPG_SECRET_KEY_PASS }},--batch,--yes,-a,-b,--pinentry-mode,loopback" --publishArtifacts __.publishArtifacts --readTimeout 600000 --awaitTimeout 600000 --release true --signed true
+        run: MILL_VERSION="0.12.14" ./millw -i --import "ivy:com.lihaoyi::mill-contrib-sonatypecentral:" mill.contrib.sonatypecentral.SonatypeCentralPublishModule/publishAll --publishArtifacts __.publishArtifacts
+        env:
+          MILL_PGP_PASSPHRASE: ${{ secrets.GPG_SECRET_KEY_PASS }}
+          # MILL_PGP_SECRET_BASE64: ${{ secrets.GPG_SECRET_KEY }}
+          MILL_SONATYPE_PASSWORD: ${{ secrets.MILL_SONATYPE_PASSWORD }}
+          MILL_SONATYPE_USERNAME: ${{ secrets.MILL_SONATYPE_USERNAME }}

--- a/millw
+++ b/millw
@@ -1,20 +1,52 @@
 #!/usr/bin/env sh
 
-# This is a wrapper script, that automatically download mill from GitHub release pages
-# You can give the required mill version with --mill-version parameter
-# If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
+# This is a wrapper script, that automatically selects or downloads Mill from Maven Central or GitHub release pages.
 #
-# Project page: https://github.com/lefou/millw
-# Script Version: 0.4.2
+# This script determines the Mill version to use by trying these sources
+#   - env-variable `MILL_VERSION`
+#   - local file `.mill-version`
+#   - local file `.config/mill-version`
+#   - `mill-version` from YAML fronmatter of current buildfile
+#   - if accessible, find the latest stable version available on Maven Central (https://repo1.maven.org/maven2)
+#   - env-variable `DEFAULT_MILL_VERSION`
+#
+# If a version has the suffix '-native' a native binary will be used.
+# If a version has the suffix '-jvm' an executable jar file will be used, requiring an already installed Java runtime.
+# If no such suffix is found, the script will pick a default based on version and platform.
+#
+# Once a version was determined, it tries to use either
+#    - a system-installed mill, if found and it's version matches
+#    - an already downloaded version under ~/.cache/mill/download
+#
+# If no working mill version was found on the system,
+# this script downloads a binary file from Maven Central or Github Pages (this is version dependent)
+# into a cache location (~/.cache/mill/download).
+#
+# Mill Project URL: https://github.com/com-lihaoyi/mill
+# Script Version: 1.0.0-M1-21-7b6fae-DIRTY892b63e8
 #
 # If you want to improve this script, please also contribute your changes back!
+# This script was generated from: dist/scripts/src/mill.sh
 #
 # Licensed under the Apache License, Version 2.0
 
-
-DEFAULT_MILL_VERSION=0.10.0
-
 set -e
+
+if [ "$1" = "--setup-completions" ] ; then
+  # Need to preserve the first position of those listed options
+  MILL_FIRST_ARG=$1
+  shift
+fi
+
+if [ -z "${DEFAULT_MILL_VERSION}" ] ; then
+  DEFAULT_MILL_VERSION="0.12.10"
+fi
+
+
+if [ -z "${GITHUB_RELEASE_CDN}" ] ; then
+  GITHUB_RELEASE_CDN=""
+fi
+
 
 MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
 
@@ -24,16 +56,17 @@ fi
 
 # Explicit commandline argument takes precedence over all other methods
 if [ "$1" = "--mill-version" ] ; then
-  shift
-  if [ "x$1" != "x" ] ; then
-    MILL_VERSION="$1"
-    shift
-  else
-    echo "You specified --mill-version without a version." 1>&2
-    echo "Please provide a version that matches one provided on" 1>&2
-    echo "${MILL_REPO_URL}/releases" 1>&2
-    false
-  fi
+    echo "The --mill-version option is no longer supported." 1>&2
+fi
+
+MILL_BUILD_SCRIPT=""
+
+if [ -f "build.mill" ] ; then
+  MILL_BUILD_SCRIPT="build.mill"
+elif [ -f "build.mill.scala" ] ; then
+  MILL_BUILD_SCRIPT="build.mill.scala"
+elif [ -f "build.sc" ] ; then
+  MILL_BUILD_SCRIPT="build.sc"
 fi
 
 # Please note, that if a MILL_VERSION is already set in the environment,
@@ -42,21 +75,25 @@ fi
 # If not already set, read .mill-version file
 if [ -z "${MILL_VERSION}" ] ; then
   if [ -f ".mill-version" ] ; then
-    MILL_VERSION="$(head -n 1 .mill-version 2> /dev/null)"
+    MILL_VERSION="$(tr '\r' '\n' < .mill-version | head -n 1 2> /dev/null)"
+  elif [ -f ".config/mill-version" ] ; then
+    MILL_VERSION="$(tr '\r' '\n' < .config/mill-version | head -n 1 2> /dev/null)"
+  elif [ -n "${MILL_BUILD_SCRIPT}" ] ; then
+    MILL_VERSION="$(cat ${MILL_BUILD_SCRIPT} | grep '//[|]  *mill-version:  *' | sed 's;//|  *mill-version:  *;;')"
   fi
 fi
 
-if [ -n "${XDG_CACHE_HOME}" ] ; then
-  MILL_DOWNLOAD_PATH="${XDG_CACHE_HOME}/mill/download"
-else
-  MILL_DOWNLOAD_PATH="${HOME}/.cache/mill/download"
+MILL_USER_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/mill"
+
+if [ -z "${MILL_DOWNLOAD_PATH}" ] ; then
+  MILL_DOWNLOAD_PATH="${MILL_USER_CACHE_DIR}/download"
 fi
 
 # If not already set, try to fetch newest from Github
 if [ -z "${MILL_VERSION}" ] ; then
   # TODO: try to load latest version from release page
   echo "No mill version specified." 1>&2
-  echo "You should provide a version via '.mill-version' file or --mill-version option." 1>&2
+  echo "You should provide a version via a '//| mill-version: ' comment or a '.mill-version' file." 1>&2
 
   mkdir -p "${MILL_DOWNLOAD_PATH}"
   LANG=C touch -d '1 hour ago' "${MILL_DOWNLOAD_PATH}/.expire_latest" 2>/dev/null || (
@@ -92,80 +129,205 @@ if [ -z "${MILL_VERSION}" ] ; then
   fi
 fi
 
-MILL="${MILL_DOWNLOAD_PATH}/${MILL_VERSION}"
+MILL_NATIVE_SUFFIX="-native"
+MILL_JVM_SUFFIX="-jvm"
+FULL_MILL_VERSION=$MILL_VERSION
+ARTIFACT_SUFFIX=""
+set_artifact_suffix(){
+  if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" = "Linux" ]; then
+    if [ "$(uname -m)" = "aarch64" ]; then
+      ARTIFACT_SUFFIX="-native-linux-aarch64"
+    else
+      ARTIFACT_SUFFIX="-native-linux-amd64"
+    fi
+  elif [ "$(uname)" = "Darwin" ]; then
+    if [ "$(uname -m)" = "arm64" ]; then
+      ARTIFACT_SUFFIX="-native-mac-aarch64"
+    else
+      ARTIFACT_SUFFIX="-native-mac-amd64"
+    fi
+  else
+     echo "This native mill launcher supports only Linux and macOS." 1>&2
+     exit 1
+  fi
+}
+
+case "$MILL_VERSION" in
+    *"$MILL_NATIVE_SUFFIX")
+  MILL_VERSION=${MILL_VERSION%"$MILL_NATIVE_SUFFIX"}
+  set_artifact_suffix
+  ;;
+
+    *"$MILL_JVM_SUFFIX")
+    MILL_VERSION=${MILL_VERSION%"$MILL_JVM_SUFFIX"}
+  ;;
+
+    *)
+  case "$MILL_VERSION" in
+    0.1.*) ;;
+    0.2.*) ;;
+    0.3.*) ;;
+    0.4.*) ;;
+    0.5.*) ;;
+    0.6.*) ;;
+    0.7.*) ;;
+    0.8.*) ;;
+    0.9.*) ;;
+    0.10.*) ;;
+    0.11.*) ;;
+    0.12.*) ;;
+    *)
+      set_artifact_suffix
+  esac
+  ;;
+esac
+
+MILL="${MILL_DOWNLOAD_PATH}/$MILL_VERSION$ARTIFACT_SUFFIX"
 
 try_to_use_system_mill() {
+  if [ "$(uname)" != "Linux" ]; then
+    return 0
+  fi
+
   MILL_IN_PATH="$(command -v mill || true)"
 
   if [ -z "${MILL_IN_PATH}" ]; then
-    return
+    return 0
   fi
 
-  UNIVERSAL_SCRIPT_MAGIC="@ 2>/dev/null # 2>nul & echo off & goto BOF"
+  SYSTEM_MILL_FIRST_TWO_BYTES=$(head --bytes=2 "${MILL_IN_PATH}")
+  if [ "${SYSTEM_MILL_FIRST_TWO_BYTES}" = "#!" ]; then
+	  # MILL_IN_PATH is (very likely) a shell script and not the mill
+	  # executable, ignore it.
+	  return 0
+  fi
 
-  if ! head -c 128 "${MILL_IN_PATH}" | grep -qF "${UNIVERSAL_SCRIPT_MAGIC}"; then
-    if [ -n "${MILLW_VERBOSE}" ]; then
-      echo "Could not determine mill version of ${MILL_IN_PATH}, as it does not start with the universal script magic2" 1>&2
+  SYSTEM_MILL_PATH=$(readlink -e "${MILL_IN_PATH}")
+  SYSTEM_MILL_SIZE=$(stat --format=%s "${SYSTEM_MILL_PATH}")
+  SYSTEM_MILL_MTIME=$(stat --format=%y "${SYSTEM_MILL_PATH}")
+
+  if [ ! -d "${MILL_USER_CACHE_DIR}" ]; then
+    mkdir -p "${MILL_USER_CACHE_DIR}"
+  fi
+
+  SYSTEM_MILL_INFO_FILE="${MILL_USER_CACHE_DIR}/system-mill-info"
+  if [ -f "${SYSTEM_MILL_INFO_FILE}" ]; then
+    parseSystemMillInfo() {
+        LINE_NUMBER="${1}"
+        # Select the line number of the SYSTEM_MILL_INFO_FILE, cut the
+        # variable definition in that line in two halves and return
+        # the value, and finally remove the quotes.
+        sed -n "${LINE_NUMBER}p" "${SYSTEM_MILL_INFO_FILE}" |\
+            cut -d= -f2 |\
+            sed 's/"\(.*\)"/\1/'
+    }
+
+    CACHED_SYSTEM_MILL_PATH=$(parseSystemMillInfo 1)
+    CACHED_SYSTEM_MILL_VERSION=$(parseSystemMillInfo 2)
+    CACHED_SYSTEM_MILL_SIZE=$(parseSystemMillInfo 3)
+    CACHED_SYSTEM_MILL_MTIME=$(parseSystemMillInfo 4)
+
+    if [ "${SYSTEM_MILL_PATH}" = "${CACHED_SYSTEM_MILL_PATH}" ] \
+           && [ "${SYSTEM_MILL_SIZE}" = "${CACHED_SYSTEM_MILL_SIZE}" ] \
+           && [ "${SYSTEM_MILL_MTIME}" = "${CACHED_SYSTEM_MILL_MTIME}" ]; then
+      if [ "${CACHED_SYSTEM_MILL_VERSION}" = "${MILL_VERSION}" ]; then
+          MILL="${SYSTEM_MILL_PATH}"
+          return 0
+      else
+          return 0
+      fi
     fi
-    return
   fi
 
-  # Roughly the size of the universal script.
-  MILL_VERSION_SEARCH_RANGE="2403"
-  MILL_IN_PATH_VERSION=$(head -c "${MILL_VERSION_SEARCH_RANGE}" "${MILL_IN_PATH}" |\
-                         sed -n 's/^.*-DMILL_VERSION=\([^\s]*\) .*$/\1/p' |\
-                         head -n 1)
+  SYSTEM_MILL_VERSION=$(${SYSTEM_MILL_PATH} --version | head -n1 | sed -n 's/^Mill.*version \(.*\)/\1/p')
 
-  if [ -z "${MILL_IN_PATH_VERSION}" ]; then
-    echo "Could not determine mill version, even though ${MILL_IN_PATH} has the universal script magic" 1>&2
-    return
-  fi
+  cat <<EOF > "${SYSTEM_MILL_INFO_FILE}"
+CACHED_SYSTEM_MILL_PATH="${SYSTEM_MILL_PATH}"
+CACHED_SYSTEM_MILL_VERSION="${SYSTEM_MILL_VERSION}"
+CACHED_SYSTEM_MILL_SIZE="${SYSTEM_MILL_SIZE}"
+CACHED_SYSTEM_MILL_MTIME="${SYSTEM_MILL_MTIME}"
+EOF
 
-  if [ "${MILL_IN_PATH_VERSION}" = "${MILL_VERSION}" ]; then
-    MILL="${MILL_IN_PATH}"
+  if [ "${SYSTEM_MILL_VERSION}" = "${MILL_VERSION}" ]; then
+    MILL="${SYSTEM_MILL_PATH}"
   fi
 }
 try_to_use_system_mill
 
 # If not already downloaded, download it
-if [ ! -s "${MILL}" ] ; then
+if [ ! -s "${MILL}" ] || [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
+  case $MILL_VERSION in
+    0.0.* | 0.1.* | 0.2.* | 0.3.* | 0.4.* )
+      DOWNLOAD_SUFFIX=""
+      DOWNLOAD_FROM_MAVEN=0
+      ;;
+    0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.0-M* )
+      DOWNLOAD_SUFFIX="-assembly"
+      DOWNLOAD_FROM_MAVEN=0
+      ;;
+    *)
+      DOWNLOAD_SUFFIX="-assembly"
+      DOWNLOAD_FROM_MAVEN=1
+      ;;
+  esac
+  case $MILL_VERSION in
+    0.12.0 | 0.12.1 | 0.12.2 | 0.12.3 | 0.12.4 | 0.12.5 | 0.12.6 | 0.12.7 | 0.12.8 | 0.12.9 | 0.12.10 | 0.12.11 )
+      DOWNLOAD_EXT="jar"
+      ;;
+    0.12.* )
+      DOWNLOAD_EXT="exe"
+      ;;
+    0.* )
+      DOWNLOAD_EXT="jar"
+      ;;
+    *)
+      DOWNLOAD_EXT="exe"
+      ;;
+  esac
 
-  # support old non-XDG download dir
-  MILL_OLD_DOWNLOAD_PATH="${HOME}/.mill/download"
-  OLD_MILL="${MILL_OLD_DOWNLOAD_PATH}/${MILL_VERSION}"
-  if [ -x "${OLD_MILL}" ] ; then
-    MILL="${OLD_MILL}"
+  DOWNLOAD_FILE=$(mktemp mill.XXXXXX)
+  if [ "$DOWNLOAD_FROM_MAVEN" = "1" ] ; then
+    DOWNLOAD_URL="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist${ARTIFACT_SUFFIX}/${MILL_VERSION}/mill-dist${ARTIFACT_SUFFIX}-${MILL_VERSION}.${DOWNLOAD_EXT}"
   else
-    VERSION_PREFIX="$(echo $MILL_VERSION | cut -b -4)"
-    case $VERSION_PREFIX in
-      0.0. | 0.1. | 0.2. | 0.3. | 0.4. )
-        DOWNLOAD_SUFFIX=""
-        ;;
-      *)
-        DOWNLOAD_SUFFIX="-assembly"
-        ;;
-    esac
-    unset VERSION_PREFIX
-
-    DOWNLOAD_FILE=$(mktemp mill.XXXXXX)
-    # TODO: handle command not found
-    echo "Downloading mill ${MILL_VERSION} from ${MILL_REPO_URL}/releases ..." 1>&2
-    MILL_VERSION_TAG=$(echo $MILL_VERSION | sed -E 's/([^-]+)(-M[0-9]+)?(-.*)?/\1\2/')
-    ${CURL_CMD} -f -L -o "${DOWNLOAD_FILE}" "${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${DOWNLOAD_SUFFIX}"
-    chmod +x "${DOWNLOAD_FILE}"
-    mkdir -p "${MILL_DOWNLOAD_PATH}"
-    mv "${DOWNLOAD_FILE}" "${MILL}"
-
-    unset DOWNLOAD_FILE
-    unset DOWNLOAD_SUFFIX
+    MILL_VERSION_TAG=$(echo "$MILL_VERSION" | sed -E 's/([^-]+)(-M[0-9]+)?(-.*)?/\1\2/')
+    DOWNLOAD_URL="${GITHUB_RELEASE_CDN}${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${DOWNLOAD_SUFFIX}"
+    unset MILL_VERSION_TAG
   fi
+
+  if [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
+    echo $DOWNLOAD_URL
+    echo $MILL
+    exit 0
+  fi
+  # TODO: handle command not found
+  echo "Downloading mill ${MILL_VERSION} from ${DOWNLOAD_URL} ..." 1>&2
+  ${CURL_CMD} -f -L -o "${DOWNLOAD_FILE}" "${DOWNLOAD_URL}"
+  chmod +x "${DOWNLOAD_FILE}"
+  mkdir -p "${MILL_DOWNLOAD_PATH}"
+  mv "${DOWNLOAD_FILE}" "${MILL}"
+
+  unset DOWNLOAD_FILE
+  unset DOWNLOAD_SUFFIX
+fi
+
+if [ -z "$MILL_MAIN_CLI" ] ; then
+  MILL_MAIN_CLI="${0}"
+fi
+
+MILL_FIRST_ARG=""
+if [ "$1" = "--bsp" ] || [ "${1#"-i"}" != "$1" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--no-daemon" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
+  # Need to preserve the first position of those listed options
+  MILL_FIRST_ARG=$1
+  shift
 fi
 
 unset MILL_DOWNLOAD_PATH
 unset MILL_OLD_DOWNLOAD_PATH
 unset OLD_MILL
 unset MILL_VERSION
-unset MILL_VERSION_TAG
 unset MILL_REPO_URL
 
-exec "${MILL}" "$@"
+# -D mill.main.cli is for compatibility with Mill 0.10.9 - 0.13.0-M2
+# We don't quote MILL_FIRST_ARG on purpose, so we can expand the empty value without quotes
+# shellcheck disable=SC2086
+exec "${MILL}" $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"

--- a/millw.bat
+++ b/millw.bat
@@ -1,13 +1,32 @@
 @echo off
 
-rem This is a wrapper script, that automatically download mill from GitHub release pages
-rem You can give the required mill version with --mill-version parameter
-rem If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
+rem This is a wrapper script, that automatically selects or downloads Mill from Maven Central or GitHub release pages.
 rem
-rem Project page: https://github.com/lefou/millw
-rem Script Version: 0.4.2
+rem This script determines the Mill version to use by trying these sources
+rem   - env-variable `MILL_VERSION`
+rem   - local file `.mill-version`
+rem   - local file `.config/mill-version`
+rem   - `mill-version` from YAML fronmatter of current buildfile
+rem   - if accessible, find the latest stable version available on Maven Central (https://repo1.maven.org/maven2)
+rem   - env-variable `DEFAULT_MILL_VERSION`
+rem
+rem If a version has the suffix '-native' a native binary will be used.
+rem If a version has the suffix '-jvm' an executable jar file will be used, requiring an already installed Java runtime.
+rem If no such suffix is found, the script will pick a default based on version and platform.
+rem
+rem Once a version was determined, it tries to use either
+rem    - a system-installed mill, if found and it's version matches
+rem    - an already downloaded version under %USERPROFILE%\.mill\download
+rem
+rem If no working mill version was found on the system,
+rem this script downloads a binary file from Maven Central or Github Pages (this is version dependent)
+rem into a cache location (%USERPROFILE%\.mill\download).
+rem
+rem Mill Project URL: https://github.com/com-lihaoyi/mill
+rem Script Version: 1.0.0-M1-21-7b6fae-DIRTY892b63e8
 rem
 rem If you want to improve this script, please also contribute your changes back!
+rem This script was generated from: dist/scripts/src/mill.bat
 rem
 rem Licensed under the Apache License, Version 2.0
 
@@ -15,101 +34,266 @@ rem setlocal seems to be unavailable on Windows 95/98/ME
 rem but I don't think we need to support them in 2019
 setlocal enabledelayedexpansion
 
-set "DEFAULT_MILL_VERSION=0.10.0"
+if [!DEFAULT_MILL_VERSION!]==[] ( set "DEFAULT_MILL_VERSION=0.12.10" )
+
+if [!MILL_GITHUB_RELEASE_CDN!]==[] ( set "MILL_GITHUB_RELEASE_CDN=" )
+
+if [!MILL_MAIN_CLI!]==[] ( set "MILL_MAIN_CLI=%~f0" )
 
 set "MILL_REPO_URL=https://github.com/com-lihaoyi/mill"
 
-rem %~1% removes surrounding quotes
-if [%~1%]==[--mill-version] (
-    rem shift command doesn't work within parentheses
-    if not [%~2%]==[] (
-        set MILL_VERSION=%~2%
-        set "STRIP_VERSION_PARAMS=true"
+SET MILL_BUILD_SCRIPT=
+
+if exist "build.mill" (
+  set MILL_BUILD_SCRIPT=build.mill
+) else (
+    if exist "build.mill.scala" (
+      set MILL_BUILD_SCRIPT=build.mill.scala
     ) else (
-        echo You specified --mill-version without a version. 1>&2
-        echo Please provide a version that matches one provided on 1>&2
-        echo %MILL_REPO_URL%/releases 1>&2
-        exit /b 1
+        if exist "build.sc" (
+          set MILL_BUILD_SCRIPT=build.sc
+        ) else (
+            rem no-op
+        )
     )
 )
 
 if [!MILL_VERSION!]==[] (
   if exist .mill-version (
-      set /p MILL_VERSION=<.mill-version
+    set /p MILL_VERSION=<.mill-version
+  ) else (
+    if exist .config\mill-version (
+      set /p MILL_VERSION=<.config\mill-version
+    ) else (
+      if not "%MILL_BUILD_SCRIPT%"=="" (
+        for /f "tokens=1-2*" %%a in ('findstr /C:"//| mill-version:" %MILL_BUILD_SCRIPT%') do (
+          set "MILL_VERSION=%%c"
+        )
+      ) else (
+        rem no-op
+      )
+    )
   )
 )
 
-if [!MILL_VERSION!]==[] (
-    set MILL_VERSION=%DEFAULT_MILL_VERSION%
-)
+if [!MILL_VERSION!]==[] set MILL_VERSION=%DEFAULT_MILL_VERSION%
 
-set MILL_DOWNLOAD_PATH=%USERPROFILE%\.mill\download
+if [!MILL_DOWNLOAD_PATH!]==[] set MILL_DOWNLOAD_PATH=%USERPROFILE%\.mill\download
 
 rem without bat file extension, cmd doesn't seem to be able to run it
-set MILL=%MILL_DOWNLOAD_PATH%\!MILL_VERSION!.bat
+
+set "MILL_NATIVE_SUFFIX=-native"
+set "MILL_JVM_SUFFIX=-jvm"
+set "FULL_MILL_VERSION=%MILL_VERSION%"
+set "MILL_EXT=.bat"
+set "ARTIFACT_SUFFIX="
+REM Check if MILL_VERSION contains MILL_NATIVE_SUFFIX
+echo !MILL_VERSION! | findstr /C:"%MILL_NATIVE_SUFFIX%" >nul
+if !errorlevel! equ 0 (
+    set "MILL_VERSION=%MILL_VERSION:-native=%"
+    REM -native images compiled with graal do not support windows-arm
+    REM https://github.com/oracle/graal/issues/9215
+    IF /I NOT "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+        set "ARTIFACT_SUFFIX=-native-windows-amd64"
+        set "MILL_EXT=.exe"
+    ) else (
+        rem no-op
+    )
+) else (
+    echo !MILL_VERSION! | findstr /C:"%MILL_JVM_SUFFIX%" >nul
+    if !errorlevel! equ 0 (
+        set "MILL_VERSION=%MILL_VERSION:-jvm=%"
+    ) else (
+        set "SKIP_VERSION=false"
+        set "MILL_PREFIX=%MILL_VERSION:~0,4%"
+        if "!MILL_PREFIX!"=="0.1." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.2." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.3." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.4." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.5." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.6." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.7." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.8." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.9." set "SKIP_VERSION=true"
+        set "MILL_PREFIX=%MILL_VERSION:~0,5%"
+        if "!MILL_PREFIX!"=="0.10." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.11." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.12." set "SKIP_VERSION=true"
+
+        if "!SKIP_VERSION!"=="false" (
+            IF /I NOT "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+                set "ARTIFACT_SUFFIX=-native-windows-amd64"
+                set "MILL_EXT=.exe"
+            )
+        ) else (
+            rem no-op
+        )
+    )
+)
+
+set MILL=%MILL_DOWNLOAD_PATH%\!FULL_MILL_VERSION!!MILL_EXT!
+
+set MILL_RESOLVE_DOWNLOAD=
 
 if not exist "%MILL%" (
-    set VERSION_PREFIX=%MILL_VERSION:~0,4%
-    set DOWNLOAD_SUFFIX=-assembly
-    if [!VERSION_PREFIX!]==[0.0.] set DOWNLOAD_SUFFIX=
-    if [!VERSION_PREFIX!]==[0.1.] set DOWNLOAD_SUFFIX=
-    if [!VERSION_PREFIX!]==[0.2.] set DOWNLOAD_SUFFIX=
-    if [!VERSION_PREFIX!]==[0.3.] set DOWNLOAD_SUFFIX=
-    if [!VERSION_PREFIX!]==[0.4.] set DOWNLOAD_SUFFIX=
-    set VERSION_PREFIX=
+  set MILL_RESOLVE_DOWNLOAD=true
+) else (
+    if defined MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT (
+        set MILL_RESOLVE_DOWNLOAD=true
+    ) else (
+        rem no-op
+    )
+)
+
+
+if [!MILL_RESOLVE_DOWNLOAD!]==[true] (
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,4%
+    set MILL_SHORT_VERSION_PREFIX=%MILL_VERSION:~0,2%
+    rem Since 0.5.0
+    set MILL_DOWNLOAD_SUFFIX=-assembly
+    rem Since 0.11.0
+    set MILL_DOWNLOAD_FROM_MAVEN=1
+    if [!MILL_VERSION_PREFIX!]==[0.0.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.1.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.2.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.3.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.4.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.5.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.6.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.7.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.8.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.9.] set MILL_DOWNLOAD_FROM_MAVEN=0
+
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,5%
+    if [!MILL_VERSION_PREFIX!]==[0.10.] set MILL_DOWNLOAD_FROM_MAVEN=0
+
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,8%
+    if [!MILL_VERSION_PREFIX!]==[0.11.0-M] set MILL_DOWNLOAD_FROM_MAVEN=0
+
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,5%
+    set DOWNLOAD_EXT=exe
+    if [!MILL_SHORT_VERSION_PREFIX!]==[0.] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION_PREFIX!]==[0.12.] set DOWNLOAD_EXT=exe
+    if [!MILL_VERSION!]==[0.12.0] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.1] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.2] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.3] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.4] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.5] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.6] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.7] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.8] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.9] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.10] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.11] set DOWNLOAD_EXT=jar
+
+    set MILL_VERSION_PREFIX=
+    set MILL_SHORT_VERSION_PREFIX=
 
     for /F "delims=- tokens=1" %%A in ("!MILL_VERSION!") do set MILL_VERSION_BASE=%%A
+    set MILL_VERSION_MILESTONE=
     for /F "delims=- tokens=2" %%A in ("!MILL_VERSION!") do set MILL_VERSION_MILESTONE=%%A
-	set VERSION_MILESTONE_START=!MILL_VERSION_MILESTONE:~0,1!
-    if [!VERSION_MILESTONE_START!]==[M] (
-        set MILL_VERSION_TAG="!MILL_VERSION_BASE!-!MILL_VERSION_MILESTONE!"
+    set MILL_VERSION_MILESTONE_START=!MILL_VERSION_MILESTONE:~0,1!
+    if [!MILL_VERSION_MILESTONE_START!]==[M] (
+        set MILL_VERSION_TAG=!MILL_VERSION_BASE!-!MILL_VERSION_MILESTONE!
     ) else (
         set MILL_VERSION_TAG=!MILL_VERSION_BASE!
     )
+    if [!MILL_DOWNLOAD_FROM_MAVEN!]==[1] (
+        set MILL_DOWNLOAD_URL=https://repo1.maven.org/maven2/com/lihaoyi/mill-dist!ARTIFACT_SUFFIX!/!MILL_VERSION!/mill-dist!ARTIFACT_SUFFIX!-!MILL_VERSION!.!DOWNLOAD_EXT!
+    ) else (
+        set MILL_DOWNLOAD_URL=!MILL_GITHUB_RELEASE_CDN!%MILL_REPO_URL%/releases/download/!MILL_VERSION_TAG!/!MILL_VERSION!!MILL_DOWNLOAD_SUFFIX!
+    )
+
+    if defined MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT (
+        echo !MILL_DOWNLOAD_URL!
+        echo !MILL!
+        exit /b 0
+    )
 
     rem there seems to be no way to generate a unique temporary file path (on native Windows)
-    set DOWNLOAD_FILE=%MILL%.tmp
+    set MILL_DOWNLOAD_FILE=%MILL%.tmp
 
-    set DOWNLOAD_URL=%MILL_REPO_URL%/releases/download/!MILL_VERSION_TAG!/!MILL_VERSION!!DOWNLOAD_SUFFIX!
-
-    echo Downloading mill %MILL_VERSION% from %MILL_REPO_URL%/releases ... 1>&2
+    echo Downloading mill !MILL_VERSION! from !MILL_DOWNLOAD_URL! ... 1>&2
 
     if not exist "%MILL_DOWNLOAD_PATH%" mkdir "%MILL_DOWNLOAD_PATH%"
     rem curl is bundled with recent Windows 10
     rem but I don't think we can expect all the users to have it in 2019
     where /Q curl
-    if %ERRORLEVEL% EQU 0 (
-        curl -f -L "!DOWNLOAD_URL!" -o "!DOWNLOAD_FILE!"
+    if !ERRORLEVEL! EQU 0 (
+        curl -f -L "!MILL_DOWNLOAD_URL!" -o "!MILL_DOWNLOAD_FILE!"
     ) else (
         rem bitsadmin seems to be available on Windows 7
         rem without /dynamic, github returns 403
         rem bitsadmin is sometimes needlessly slow but it looks better with /priority foreground
-        bitsadmin /transfer millDownloadJob /dynamic /priority foreground "!DOWNLOAD_URL!" "!DOWNLOAD_FILE!"
+        bitsadmin /transfer millDownloadJob /dynamic /priority foreground "!MILL_DOWNLOAD_URL!" "!MILL_DOWNLOAD_FILE!"
     )
-    if not exist "!DOWNLOAD_FILE!" (
-        echo Could not download mill %MILL_VERSION% 1>&2
+    if not exist "!MILL_DOWNLOAD_FILE!" (
+        echo Could not download mill !MILL_VERSION! 1>&2
         exit /b 1
     )
 
-    move /y "!DOWNLOAD_FILE!" "%MILL%"
+    move /y "!MILL_DOWNLOAD_FILE!" "%MILL%"
 
-    set DOWNLOAD_FILE=
-    set DOWNLOAD_SUFFIX=
+    set MILL_DOWNLOAD_FILE=
+    set MILL_DOWNLOAD_SUFFIX=
 )
 
 set MILL_DOWNLOAD_PATH=
 set MILL_VERSION=
 set MILL_REPO_URL=
 
-set MILL_PARAMS=%*
-
-if defined STRIP_VERSION_PARAMS (
-    for /f "tokens=1-2*" %%a in ("%*") do (
-        rem strip %%a - It's the "--mill-version" option.
-        rem strip %%b - it's the version number that comes after the option.
-        rem keep  %%c - It's the remaining options.
-        set MILL_PARAMS=%%c
+rem Need to preserve the first position of those listed options
+set MILL_FIRST_ARG=
+if [%~1%]==[--bsp] (
+  set MILL_FIRST_ARG=%1%
+) else (
+  if [%~1%]==[-i] (
+    set MILL_FIRST_ARG=%1%
+  ) else (
+    if [%~1%]==[--interactive] (
+      set MILL_FIRST_ARG=%1%
+    ) else (
+      if [%~1%]==[--no-server] (
+        set MILL_FIRST_ARG=%1%
+      ) else (
+        if [%~1%]==[--no-daemon] (
+          set MILL_FIRST_ARG=%1%
+        ) else (
+          if [%~1%]==[--repl] (
+            set MILL_FIRST_ARG=%1%
+          ) else (
+            if [%~1%]==[--help] (
+              set MILL_FIRST_ARG=%1%
+            )
+          )
+        )
+      )
     )
+  )
+)
+set "MILL_PARAMS=%*%"
+
+if not [!MILL_FIRST_ARG!]==[] (
+  for /f "tokens=1*" %%a in ("%*") do (
+    set "MILL_PARAMS=%%b"
+  )
 )
 
-"%MILL%" %MILL_PARAMS%
+rem -D mill.main.cli is for compatibility with Mill 0.10.9 - 0.13.0-M2
+"%MILL%" %MILL_FIRST_ARG% -D "mill.main.cli=%MILL_MAIN_CLI%" %MILL_PARAMS%


### PR DESCRIPTION
We can't yet test with Mill 0.12, but we need Mill 0.12 to run the new mill-contrib-sonatypecentral plugin for publishing. Hence, we just use newer Mill for publishing, but not testing.

Updated Mill wrapper scripts to 1.0.0-M1-21-7b6fae-DIRTY892b63e8

